### PR TITLE
Update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,15 +1,49 @@
+<!--
+This issue tracker is for *bug reports* and *feature requests*.
+For questions, and getting help on using docker:
+
+- Docker documentation - https://docs.docker.com
+- Docker Forums - https://forums.docker.com
+- Docker community Slack - https://dockercommunity.slack.com/ (register here: http://dockr.ly/community)
+- Post a question on StackOverflow, using the Docker tag
+-->
+
+* [x] This is a bug report
+* [ ] This is a feature request
+* [ ] I searched existing issues before opening this one
+
+<!--
+DO NOT report security issues publicly! If you suspect you discovered
+a security issue, send your report privately to security@docker.com.
+-->
+
 ### Expected behavior
+
 
 ### Actual behavior
 
-### Information
-
-  - Linux distro, e.g. Ubuntu Xenial
-  - Docker CE version, can be found from output of `docker vesion`
-  - A reproducible case if this is a bug, Dockerfiles FTW
-  - Page URL if this is a docs issue or the name of a man page
 
 ### Steps to reproduce the behavior
 
-  1. ...
-  2. ...
+<!--
+Describe the exact steps to reproduce. If possible, provide a *minimum*
+reproduction example; take into account that others do not have access
+to your private images, source code, and environment.
+
+REMOVE SENSITIVE DATA BEFORE POSTING (replace those parts with "REDACTED")
+-->
+
+**Output of `docker version`:**
+
+```
+(paste your output here)
+```
+
+**Output of `docker info`:**
+
+```
+(paste your output here)
+```
+
+**Additional environment details (AWS, VirtualBox, physical, etc.)**
+


### PR DESCRIPTION
The existing template did not request "docker version"
and "docker info"

Also added information about reporting security issues,
where to get help, etc.
