### PR TITLE
Update info on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,21 @@
-## Docker CE for Linux
+## Docker Engine for Linux
 
-### Getting Docker CE for Linux
+This is a legacy issue tracker to manage issues related with Docker Engine for Linux. To report an issue or request a new feature please refer to the upstream [Moby Project](https://github.com/moby/moby), or [Docker Deskop for Linux](https://github.com/docker/desktop-linux/issues) in case you are running [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
-"Docker CE for Linux" is specialized packages for common Linux distributions which are free to [download](https://store.docker.com/search?offering=community&operating_system=linux&platform=server&q=&type=edition).
+### Getting Docker Engine for Linux
+
+Docker Engine for Linux are specialized packages for common Linux distributions which are free to [download](https://download.docker.com/linux/static/stable/).
 
 ### Documentation
 
-If you don't understand something about Docker CE for Linux, the [extensive
+If you don't understand something about Docker Engine for Linux, the [extensive
 documentation](https://docs.docker.com/engine/installation/) is a great place
 to look for answers.
 
 ### Support
 
-Users from the Docker CE community trade tips and tricks and discuss Docker CE
+Users from the Docker Engine community trade tips and tricks and discuss Docker Engine
 for Linux in [the user forum](https://forums.docker.com/categories).
 
-Problems with the Docker CE for Linux deployment can be filed as issues in this
-([docker/for-linux](https://github.com/docker/for-linux)) repository.
-
-### This Repository
-
-This repository contains an issue tracker for Docker CE for Linux. If you find
-a problem with the software, first [browse the existing
-issues](https://github.com/docker/for-linux/issues) or search from the bar
-at the top (`s` to focus) and then, if you don't find your issue, [open
-a new issue](https://github.com/docker/for-linux/issues/new).
-
-### Labels
-
-Initially, issues are
-[unlabeled](https://github.com/docker/for-linux/issues?q=is%3Aopen+is%3Aissue+no%3Alabel). Issues
-are labeled in order to make tracking them easier. The meaning of the
-labels is roughly:
-
-| Label            | Meaning                                            |
-|------------------|----------------------------------------------------|
-| [area/cli](https://github.com/docker/for-linux/labels/area/cli)      | related to the Docker client |
-| [area/engine](https://github.com/docker/for-linux/labels/area/engine)      | related to the Docker engine |
-| [area/mounts](https://github.com/docker/for-linux/labels/area/mounts)      | related to `-v` bind mounts |
-| [area/network](https://github.com/docker/for-linux/labels/area/network)     | related to container networking |
-| [area/startup](https://github.com/docker/for-linux/labels/area/startup)     | related to application installation or initialization |
-| [area/storage](https://github.com/docker/for-linux/labels/area/storage)     | related to image and container storage ([storage drivers](https://docs.docker.com/engine/userguide/storagedriver/imagesandcontainers/)) |
-| [area/volumes](https://github.com/docker/for-linux/labels/area/volumes)     | related to Docker volumes ([volume drivers](https://docs.docker.com/engine/reference/commandline/volume_create/)) |
-| [kind/bug](https://github.com/docker/for-linux/labels/kind/bug)         | this issue describes a defect |
-| [kind/docs](https://github.com/docker/for-linux/labels/kind/docs)        | this issue describes a documentation change |
-| [kind/enhancement](https://github.com/docker/for-linux/labels/kind/enhancement) | this issue describes a change to existing functionality |
-| [kind/feature](https://github.com/docker/for-linux/labels/kind/feature)     | this issue describes totally new functionality |
-| [kind/performance](https://github.com/docker/for-linux/labels/kind/performance) | this issue describes a performance problem or measurement |
-| [status/0-triage](https://github.com/docker/for-linux/labels/status/0-triage) | The issue needs triaging |
-| [status/0-wont-fix](https://github.com/docker/for-linux/labels/status/0-wont-fix) | This issue will not be fixed and therefore can be closed |
-| [status/0-more-info-needed](https://github.com/docker/for-linux/labels/status/0-more-info-needed) | The issue needs more information before it can be triaged |
-| [status/1-acknowledged](https://github.com/docker/for-linux/labels/status/1-acknowledged) | The issue has been triaged and is being investigated |
-| [status/2-in-progress](https://github.com/docker/for-linux/labels/status/2-in-progress) | The issue has been assigned to a engineer and is waiting a fix |
-| [status/3-fixed](https://github.com/docker/for-linux/labels/status/3-fixed) | The issue has been fixed in `master` |
-| [status/4-fix-released](https://github.com/docker/for-linux/labels/status/4-fix-released) | The fix has been released! |
+### Security and Vulnerabilities
+Please report any security issues or vulnerabilities responsibly to the [Docker security team](https://github.com/moby/moby/security/policy). Please do not use the public issue tracker.


### PR DESCRIPTION
Replaced old references to "Docker CE" by "Docker Engine" and
removed legacy info

Signed-off-by: bsousaa <bruno.sousa@docker.com>