### PR TITLE
Add stale bot to process issues from 2017

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 1725
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,9 +5,9 @@ daysUntilClose: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
-  - security
+  - lifecycle/frozen
 # Label to use when marking an issue as stale
-staleLabel: stale
+staleLabel: lifecycle/stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
This includes the configuration for the stale bot to start removing issues that have no activity in this repo.

We will start with issues from 2017, roughly 50 and see how it evolves. We give 30 days of inactivity before closing.

Signed-off-by: Bruno Sousa <bruno.sousa@docker.com>